### PR TITLE
libtapi: fix build on ppc & ppc64

### DIFF
--- a/src/llvm/projects/clang/lib/Lex/Lexer.cpp
+++ b/src/llvm/projects/clang/lib/Lex/Lexer.cpp
@@ -2573,7 +2573,7 @@ bool Lexer::SkipBlockComment(Token &Result, const char *CurPtr,
         '/', '/', '/', '/',  '/', '/', '/', '/'
       };
       while (CurPtr+16 <= BufferEnd &&
-             !vec_any_eq(*(const vector unsigned char*)CurPtr, Slashes))
+             !vec_any_eq(*(const __vector unsigned char*)CurPtr, Slashes))
         CurPtr += 16;
 #else
       // Scan for '/' quickly.  Many block comments are very large.

--- a/src/llvm/projects/libtapi/include/tapi/Core/Architecture.def
+++ b/src/llvm/projects/libtapi/include/tapi/Core/Architecture.def
@@ -4,6 +4,15 @@
 #define ARCHINFO(arch)
 #endif
 
+
+#ifdef SUPPORT_ARCH_PPC
+ARCHINFO(ppc, MachO::CPU_TYPE_POWERPC, MachO::CPU_SUBTYPE_POWERPC_ALL)
+#endif
+
+#ifdef SUPPORT_ARCH_PPC64
+ARCHINFO(ppc64, MachO::CPU_TYPE_POWERPC64, MachO::CPU_SUBTYPE_POWERPC_ALL)
+#endif
+
 ///
 /// X86 architectures sorted by cpu type and sub type id.
 ///


### PR DESCRIPTION
This combines two patches:
1. https://github.com/macports/macports-ports/commit/df4b5f68cbad270b6f72b966b1c6a3d67a26c46a
2. https://github.com/iains/tapi/commit/0b204f83e9907456deb1a44ab36f08a8362fd6f0

Together, this fixes building for `ppc` and `ppc64` on 10.5.8, 10.6 PPC and 10.6.8 Rosetta.