### PR TITLE
Also build tapi binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ pushd build &>/dev/null
 
 INSTALLPREFIX=$(cat INSTALLPREFIX)
 
-$MAKE install-libtapi install-tapi-headers -j $JOBS
+$MAKE install-libtapi install-tapi-headers install-tapi -j $JOBS
 
 popd &>/dev/null
 popd &>/dev/null


### PR DESCRIPTION
Commit [d6d145](https://github.com/tpoechtrager/apple-libtapi/commit/d6d145fb8a83320b87c506a6f302a8124d988030) re-enabled building of the tapi binary, so this pr allows for that to be installed alongside libtapi via the install script 