### PR TITLE
macOS 10.5 hasn't got pthread_setname_np

### DIFF
--- a/src/llvm/lib/Support/Unix/Threading.inc
+++ b/src/llvm/lib/Support/Unix/Threading.inc
@@ -154,7 +154,9 @@ void llvm::set_thread_name(const Twine &Name) {
   ::pthread_setname_np(::pthread_self(), "%s",
     const_cast<char *>(NameStr.data()));
 #elif defined(__APPLE__)
+#if HAVE_PTHREAD_SETNAME_NP
   ::pthread_setname_np(NameStr.data());
+#endif
 #endif
 }
 


### PR DESCRIPTION
protect a call `pthread_setname_np` by `HAVE_PTHREAD_SETNAME_NP`