### PR TITLE
Extra fixes for Darwin PowerPC

### DIFF
--- a/src/llvm/lib/Support/LockFileManager.cpp
+++ b/src/llvm/lib/Support/LockFileManager.cpp
@@ -31,7 +31,7 @@
 #include <unistd.h>
 #endif
 
-#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && (__MAC_OS_X_VERSION_MIN_REQUIRED > 1050)
+#if defined(__APPLE__) && defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && (__MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__POWERPC__)
 #define USE_OSX_GETHOSTUUID 1
 #else
 #define USE_OSX_GETHOSTUUID 0

--- a/src/llvm/lib/Support/Unix/Threading.inc
+++ b/src/llvm/lib/Support/Unix/Threading.inc
@@ -154,7 +154,11 @@ void llvm::set_thread_name(const Twine &Name) {
   ::pthread_setname_np(::pthread_self(), "%s",
     const_cast<char *>(NameStr.data()));
 #elif defined(__APPLE__)
+#if defined(__POWERPC__)
+  ::pthread_setname_np((char*) NameStr.data());
+#else
   ::pthread_setname_np(NameStr.data());
+#endif
 #endif
 }
 


### PR DESCRIPTION
This PR adds two minor fixes for:

1. Invalid conversion from `const char*` to `char*` in `Threading.inc` (error observed on PPC, Intel does not need a fix).
2. `gethostuuid` not declared in `LockFileManager.cpp` (error seems to be specific to 10.6 PPC, where uuid/uuid.h does not yet have its implementation); therefore, do not use it for PPC in general (for <10.6 it is not used anyway, so only 10.6 PPC case is taken care of).