### PR TITLE
Enable build `Diagnostics`

### DIFF
--- a/src/tapi/include/tapi/CMakeLists.txt
+++ b/src/tapi/include/tapi/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory(Driver)
-#add_subdirectory(Diagnostics)
+add_subdirectory(Diagnostics)

--- a/src/tapi/lib/CMakeLists.txt
+++ b/src/tapi/lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(Config)
 add_subdirectory(Core)
 add_subdirectory(SDKDB)
-#add_subdirectory(Diagnostics)
+add_subdirectory(Diagnostics)
 add_subdirectory(Driver)
 add_subdirectory(Frontend)
 add_subdirectory(NoInits)


### PR DESCRIPTION
`DiagnosticTAPIKinds.inc` is required by `Diagnostics.h` which required by `SDKDB.h` which required by `tapiSDKDB` target.