### PR TITLE
tapi 1300.6.5: fix building on powerpc-darwin

### DIFF
--- a/src/llvm/include/llvm/ADT/Bitfields.h
+++ b/src/llvm/include/llvm/ADT/Bitfields.h
@@ -203,7 +203,11 @@ template <typename T> struct ResolveUnderlyingType<T, false> {
 template <> struct ResolveUnderlyingType<bool, false> {
   /// In case sizeof(bool) != 1, replace `void` by an additionnal
   /// std::conditional.
+#if defined(__APPLE__) && defined(__ppc__) // Darwin ppc 32-bit ABI has 4-byte bool.
+  using type = std::conditional<sizeof(bool) == 4, uint32_t, void>::type;
+#else
   using type = std::conditional<sizeof(bool) == 1, uint8_t, void>::type;
+#endif
 };
 
 } // namespace bitfields_details

--- a/src/tapi/CMakeLists.txt
+++ b/src/tapi/CMakeLists.txt
@@ -42,7 +42,7 @@ elseif(NOT DEFINED TAPI_SUPPORTED_ARCHS)
 endif()
 message(STATUS "Supported Architectures: ${TAPI_SUPPORTED_ARCHS}")
 
-set(KNOWN_ARCHS i386 x86_64 x86_64h armv4t armv6 armv5 armv7 armv7s armv7k armv6m armv7m armv7em arm64 arm64e)
+set(KNOWN_ARCHS i386 x86_64 x86_64h armv4t armv6 armv5 armv7 armv7s armv7k armv6m armv7m armv7em arm64 arm64e ppc ppc64)
 
 set (CONFIG_FILE ${CMAKE_CURRENT_BINARY_DIR}/include/tapi/Core/ArchitectureConfig.h)
 file(WRITE ${CONFIG_FILE} "#ifndef TAPI_CORE_ARCHITECTURE_CONFIG_H\n")


### PR DESCRIPTION
@tpoechtrager Apologize for a delay, but I have fixed that build failure. Turned out, the fix is totally trivial :)

P. S. The second commit adds ppc/ppc64 to known archs. I think it is not needed to add them to supported ones [yet], since they barely are. But for sure they are known to the codebase, and can be enabled manually.