### PR TITLE
get_cpu_count.sh: avoid having to run the compiler on darwin

### DIFF
--- a/tools/cpucount/get_cpu_count.sh
+++ b/tools/cpucount/get_cpu_count.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Print the number of enabled CPUs by either using nproc or ncpus.
+# Print the number of enabled CPUs by either using nproc, ncpus, or sysctl.
 # If both commands fail, fall back to a platform-independent C++ solution.
 # If that also fails, just echo 1...
 #
@@ -9,6 +9,7 @@
 pushd "${0%/*}" &>/dev/null
 
 nproc 2>/dev/null && exit 0 || ncpus 2>/dev/null && exit 0 || {
+  [ "$(uname)" == "Darwin" ] && sysctl -n hw.ncpu 2>/dev/null && exit 0
   if [ ! -f cpucount ]; then
     c++ cpucount.cpp -std=c++0x -o cpucount &>/dev/null || { echo 1 && exit 0; }
   fi


### PR DESCRIPTION
It's extremely important that I save 1 second on my tapi builds on macOS by not having to run the C++ compiler.