### PR TITLE
fix build on musl

### DIFF
--- a/src/llvm/lib/Support/raw_ostream.cpp
+++ b/src/llvm/lib/Support/raw_ostream.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define _LARGEFILE64_SOURCE
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"


### PR DESCRIPTION
This won't be needed if tapi is ever updated to a newer upstream apple version, since that would mean updating the llvm version and upstream llvm removed lseek64 usage a while back