### PR TITLE
fix to find symbols for when arm64 is missing from the tbd slice

### DIFF
--- a/src/tapi/tools/libtapi/LinkerInterfaceFile.cpp
+++ b/src/tapi/tools/libtapi/LinkerInterfaceFile.cpp
@@ -169,6 +169,20 @@ public:
   }
 };
 
+// Find the first architecture in the set that shares the same cpu type as the
+// requested architecture. This should mirror the fallback logic in tapi 2100 for
+// handling macOS 26+ SDK .tbd files that only carry arm64e slices when arm64 is
+// requested.
+static Architecture findCompatibleArch(ArchitectureSet archs,
+                                       Architecture requestedArch) {
+  auto requestedCPUType = getCPUTypeFromArchitecture(requestedArch).first;
+  for (auto arch : archs) {
+    if (getCPUTypeFromArchitecture(arch).first == requestedCPUType)
+      return arch;
+  }
+  return AK_unknown;
+}
+
 static Architecture getArchForCPU(cpu_type_t cpuType, cpu_subtype_t cpuSubType,
                                   bool enforceCpuSubType,
                                   ArchitectureSet archs) {
@@ -179,7 +193,8 @@ static Architecture getArchForCPU(cpu_type_t cpuType, cpu_subtype_t cpuSubType,
 
   if (enforceCpuSubType)
     return AK_unknown;
-  return arch;
+
+  return findCompatibleArch(archs, arch);
 }
 
 LinkerInterfaceFile::LinkerInterfaceFile() noexcept


### PR DESCRIPTION
As was explained in issue: #49. When the arm64 is missing from the slice that contains the architectures in the tbd files, using this version of libtapi gives you back an empty symbol set. De system `.dylibs` should still contain the arm64 compatible code though, so we just use the names from the arm64e slices.

We specifically were noticing that on conda-forge simple c compilation was failing because of this. So we initially made a patch there. However, after some discussion in the issue and decompilation with claude, we decided another similar fix could be upstreamed.

I have a reproducer running, you need https://pixi.sh though to run it. That basically has a failing and working situation for the conda-forge toolchain with libtapi with this fix included. See: https://github.com/tdejager/tapi-arm64e-repro. If you want any more tests please tell me.

The fixed tapi seems to work in the reproducer though, the repository has small instructions with how to run it, again you need pixi installed.